### PR TITLE
Generate and push metrics nightly with GHA (SOFTWARE-4419)

### DIFF
--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -35,9 +35,8 @@ jobs:
         git commit -m "nightly metrics update"
 
     - name: Push changes
-      uses: ad-m/github-push-action@master
+      uses: ad-m/github-push-action@v0.6.0
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         #repository: path-cc/metrics
         branch: gh-pages
-

--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -32,7 +32,7 @@ jobs:
         git config --local user.name "Automatic preview publish"
         git add campuses-with-active-researchers.csv
         git add campus-contributions.json
-        git commit -m "nightly metrics update"
+        git commit -m "nightly metrics update (from ${GITHUB_REPOSITORY} ${GITHUB_WORKFLOW} ${GITHUB_RUN_ID}.${GITHUB_RUN_NUMBER})"
 
     - name: Push changes
       run: |

--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -1,6 +1,10 @@
 name: metrics
 
 on:
+  push:
+    branches:
+      - master
+
   schedule:
     - cron: '0 0 * * *'
 

--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -11,9 +11,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-        with:
-          persist-credentials: false  # use personal token, not GITHUB_TOKEN
-          fetch-depth: 0  # or else push will fail
 
       - name: setup and run metrics
         run: |
@@ -27,16 +24,23 @@ jobs:
 
     - name: Commit files
       run: |
-        git checkout gh-pages
-        git config --local user.email "osg-bot@users.noreply.github.com"
-        git config --local user.name "OSG-BOT"
+        git clone --depth=1 git@github.com:path-cc/metrics
+        mv campus-contributions.json metrics
+        mv campuses-with-active-researchers.csv metrics
+        cd metrics
+        git config --local user.email "help@opensciencegrid.org"
+        git config --local user.name "Automatic preview publish"
         git add campuses-with-active-researchers.csv
         git add campus-contributions.json
         git commit -m "nightly metrics update"
 
     - name: Push changes
-      uses: ad-m/github-push-action@v0.6.0
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        #repository: path-cc/metrics
-        branch: gh-pages
+      run: |
+        mkdir -p ~/.ssh
+        ssh-keyscan github.com >> ~/.ssh/known_hosts
+        ssh-agent -a "$SSH_AUTH_SOCK" > /dev/null
+        ssh-add - <<< "${{ secrets.PREVIEW_DEPLOY_KEY }}"
+        cd metrics
+        git push
+      env:
+        SSH_AUTH_SOCK: /tmp/ssh_agent.sock

--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -1,0 +1,43 @@
+name: metrics
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    if: startsWith(github.repository, 'path-cc/')
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          persist-credentials: false  # use personal token, not GITHUB_TOKEN
+          fetch-depth: 0  # or else push will fail
+
+      - name: setup and run metrics
+        run: |
+          cd campuses-with-activate-researchers
+          python3 -m venv .
+          . ./bin/activate
+          pip install -r requirements.txt
+          ./campuses-with-active-researchers.py --csv > ../campuses-with-active-researchers.csv
+          cd ..
+          ./campus-contributions --json > ../campus-contributions.json
+
+    - name: Commit files
+      run: |
+        git checkout gh-pages
+        git config --local user.email "osg-bot@users.noreply.github.com"
+        git config --local user.name "OSG-BOT"
+        git add campuses-with-active-researchers.csv
+        git add campus-contributions.json
+        git commit -m "nightly metrics update"
+
+    - name: Push changes
+      uses: ad-m/github-push-action@master
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        #repository: path-cc/metrics
+        branch: gh-pages
+

--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -39,7 +39,7 @@ jobs:
         mkdir -p ~/.ssh
         ssh-keyscan github.com >> ~/.ssh/known_hosts
         ssh-agent -a "$SSH_AUTH_SOCK" > /dev/null
-        ssh-add - <<< "${{ secrets.PREVIEW_DEPLOY_KEY }}"
+        ssh-add - <<< "${{ secrets.METRICS_DEPLOY_KEY }}"
         cd metrics
         git push
       env:


### PR DESCRIPTION
Not clear yet if this is supposed to publish to the gh-pages branch of the current repo, or of a separate `metrics` repo.

SOFTWARE-4419 seems to suggest the latter, which would require a second repo checkout, and in that case it's not so clear to me if there is anything special that will need for the `ad-m/github-push-action@master` action to work right...