### PR TITLE
fix ES setup and git clone url (SOFTWARE-4419)

### DIFF
--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Commit files
         run: |
-          git clone --depth=1 git@github.com:path-cc/metrics
+          git clone --depth=1 https://github.com/path-cc/metrics
           mv campus-contributions.json metrics
           mv campuses-with-active-researchers.csv metrics
           cd metrics
@@ -52,6 +52,7 @@ jobs:
           ssh-agent -a "$SSH_AUTH_SOCK" > /dev/null
           ssh-add - <<< "${{ secrets.METRICS_DEPLOY_KEY }}"
           cd metrics
+          git config remote.origin.pushurl git@github.com:path-cc/metrics
           git push
 
         env:

--- a/campus-contributions/oscf.py
+++ b/campus-contributions/oscf.py
@@ -11,8 +11,7 @@ from   elasticsearch_dsl import Search, A, Q
 gracc_url = 'https://gracc.opensciencegrid.org/q'
 
 es = elasticsearch.Elasticsearch(
-                [gracc_url], timeout=300, use_ssl=True, verify_certs=True,
-                ca_certs='/etc/ssl/certs/ca-bundle.crt')
+                [gracc_url], timeout=300, use_ssl=True, verify_certs=True)
 
 jobs_raw_index = 'gracc.osg.raw-*'
 jobs_summary_index = 'gracc.osg.summary'

--- a/campuses-with-active-researchers/campuses-with-active-researchers.py
+++ b/campuses-with-active-researchers/campuses-with-active-researchers.py
@@ -87,7 +87,6 @@ def get_organizations_with_active_researchers(
         timeout=300,
         use_ssl=True,
         verify_certs=True,
-        ca_certs="/etc/ssl/certs/ca-bundle.crt",
     )
 
     MAXSZ = 2 ** 30


### PR DESCRIPTION
- the /etc/ssl/certs/ca-bundle.crt path does not exist in our GHA ubuntu:latest environment, and in any case the scripts appear to work without this parameter
- clone with https url to avoid git ssh setup requirement at git clone time

@brianhlin i tested all the steps on an ubuntu:latest docker image except for the final push