### PR TITLE
Only set up a single venv

### DIFF
--- a/nightly-metrics-update.sh
+++ b/nightly-metrics-update.sh
@@ -32,13 +32,10 @@ cd ../campus-contributions
 cd ../osg-cpu-hours
 ./osg-cpu-hours.py -o ../osg-cpu-hours.json
 
-cd ..
-
-# Run the project waittime
-pushd osg-project-waittime
+cd ../osg-project-waittime
 ./calculate-waittime.py ../osg-waittime.csv $START_DATE $END_DATE
 
-popd
+cd ..
 
 
 # Commit files

--- a/nightly-metrics-update.sh
+++ b/nightly-metrics-update.sh
@@ -13,7 +13,7 @@ cd "$(dirname "$0")"
 
 python3 -m venv venv
 . venv/bin/activate
-pip install -r campuses-with-active-researchers/requirements.txt
+pip install -r requirements.txt
 
 
 # run metrics
@@ -34,14 +34,8 @@ cd ../osg-cpu-hours
 
 cd ..
 
-# Clean the environment
-deactivate
-
 # Run the project waittime
 pushd osg-project-waittime
-python3 -m venv venv
-. venv/bin/activate
-pip install -r requirements.txt
 ./calculate-waittime.py ../osg-waittime.csv $START_DATE $END_DATE
 
 popd

--- a/osg-project-waittime/requirements.txt
+++ b/osg-project-waittime/requirements.txt
@@ -1,3 +1,0 @@
-elasticsearch-dsl
-pandas
-python-dateutil

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 elasticsearch>=7.0.0,<8.0.0
 elasticsearch-dsl>=7.0.0,<8.0.0
+pandas
+python-dateutil


### PR DESCRIPTION
This is a follow-up to #22, which added a second requirements.txt and venv for the osg-project-waittime metric.

Also i tidied up the directory change management to be a bit more consistent.