### PR TITLE
Disable the GHA schedule in favor of a local cron (SOFTWARE-4651)

### DIFF
--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -10,9 +10,6 @@ on:
 
   workflow_dispatch:
 
-  schedule:
-    - cron: '0 0 * * *'
-
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
GitHub disables schedules if the repo has been inactive for 60 days