### PR TITLE
Cap numpy version below 2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+numpy<2
 opensearch-py
 pandas==1.5.3
 python-dateutil


### PR DESCRIPTION
The version of pandas we're requesting (1.5.3) is not compatible with numpy 2 -- the first version that is compatible is 2.2.2. Since that is a major version upgrade from 1.5.3, cap numpy at the 1.x series until we've had a chance to test the upgrade.