### PR TITLE
Add additional probe names to wait time calculation

### DIFF
--- a/osg-project-waittime/calculate-waittime.py
+++ b/osg-project-waittime/calculate-waittime.py
@@ -51,7 +51,10 @@ def getUsersPerDay(starttime: datetime.datetime, endtime: datetime.datetime):
                Q("term", ProbeName="condor-ap:ap21.uc.osg-htc.org") | 
                Q("term", ProbeName="condor-ap:ap22.uc.osg-htc.org") | 
                Q("term", ProbeName="condor-ap:ap23.uc.osg-htc.org") | 
-               Q("term", ProbeName="condor-ap:ap40.uw.osg-htc.org")
+               Q("term", ProbeName="condor-ap:ap40.uw.osg-htc.org") |
+               Q("term", ProbeName="condor-ap:ap41.uw.osg-htc.org") |
+               Q("term", ProbeName="condor-ap:ap42.uw.osg-htc.org") |
+               Q("term", ProbeName="condor-ap:ap43.uw.osg-htc.org")
             )
         ],
     )


### PR DESCRIPTION
Per [this JIRA issue](https://opensciencegrid.atlassian.net/browse/SOFTWARE-6294), there were two issues with this report:
* UW APs weren't configured to set the `DN` field, which is used for grouping by user
* The new UW APs (41-43) weren't included in the report.
We've resolved the DN isssue out of band and the UW APs should now be reporting that field, this small PR adds the new UW APs to the report.