### PR TITLE
Add OSG Collaborations CPU/GPU hours collection script

### DIFF
--- a/osg-collaborations-hours/README.md
+++ b/osg-collaborations-hours/README.md
@@ -1,0 +1,86 @@
+OSG Collaboration Hours
+=======================
+
+**Metric description:** CPU and GPU hours consumed on the OSPool (and collaboration-owned resources) by collaboration-level OSPool projects, broken out by pool.
+
+Process for calculating Collaboration Hours
+--------------------------------------------
+
+1. Query Elasticsearch for completed jobs within the reporting period, excluding DAGMan and scheduler universe jobs, and excluding jobs without any runtime.
+2. For each collaboration, filter jobs by `ProjectName` to the known project name variants for that collaboration.
+3. For collaborations that also run jobs on dedicated or non-OSPool resources (CLAS12, EIC/ePIC, GlueX, IceCube, SPT-3G, XENON), attribute jobs to the appropriate pool based on resource name and OSPool job classification.
+4. Sum CPU hours and GPU hours separately per pool..
+5. Write results to a CSV file with one row per collaboration-pool combination.
+
+Collaborations reported
+-----------------------
+
+| Collaboration | Pools |
+|---|---|
+| CLAS12 | OSPool, JLAB |
+| EIC/ePIC | OSPool, JLAB |
+| Event Horizon Telescope | OSPool |
+| Future Colliders | OSPool |
+| GlueX | OSPool, JLAB |
+| IceCube | OSPool, IceCube |
+| KOTO | OSPool |
+| LIGO-OSG | OSPool |
+| MOLLER | OSPool |
+| REDTOP | OSPool |
+| RNO-G | OSPool |
+| Super CDMS | OSPool |
+| SoLID | OSPool |
+| SPT-3G | OSPool, SPT |
+| XENON | OSPool, XENON |
+
+Math behind the metric
+-----------------------
+
+Metrics (from HTCondor job ClassAds):
+* `RemoteWallClockTime`: Total wall-clock seconds the job executed.
+* `RequestCpus` / `CpusProvisioned`: Number of CPUs requested or provisioned
+* `RequestGpus` / `GpusProvisioned`: Number of GPUs requested or provisioned
+
+**CPU Hours:**
+
+    CPUs = min(RequestCpus, CpusProvisioned)  [defaults to 1 if absent]
+    CPU Hours = CPUs × RemoteWallClockTime / 3600
+
+**GPU Hours** (only for jobs with `RequestGpus > 0`):
+
+    GPUs = min(RequestGpus, GpusProvisioned)  [defaults to 1 if absent]
+    GPU Hours = GPUs × RemoteWallClockTime / 3600
+
+OSPool job classification
+--------------------------
+
+A job is classified as an OSPool job if:
+
+* Its `ScheddName` matches a known OSPool access point **and** it has no `LastRemotePool`, **or**
+* Its `LastRemotePool` matches a known OSPool collector, **and**
+* It does not have a `TargetAnnexName` or a `ResourceName` of `"Local Job"` or `"2"`.
+
+For collaborations with dedicated resources, jobs running on known collaboration-specific resource names are attributed to the collaboration's own pool even if they flowed through OSPool infrastructure.
+
+Usage
+-----
+
+```
+usage: fetch_collab_metrics.py [-h] [--es-host ES_HOST] [--es-url-prefix ES_URL_PREFIX]
+                                [--es-index ES_INDEX] [--es-user ES_USER]
+                                [--es-password-file ES_PASSWORD_FILE] [--es-use-https]
+                                [--es-ca-certs ES_CA_CERTS] [--es-timeout ES_TIMEOUT]
+                                [--es-config-file ES_CONFIG_FILE]
+                                [--start YYYY-MM-DD] [--end YYYY-MM-DD]
+                                outfile
+
+positional arguments:
+  outfile               Output CSV file path.
+
+options:
+  --start YYYY-MM-DD    Start of the reporting period (inclusive). Defaults to yesterday.
+  --end YYYY-MM-DD      End of the reporting period (exclusive). Defaults to one day after --start.
+  --es-config-file      JSON file containing an object that sets ES connection options.
+```
+
+Output CSV columns: `Project, Pool, CPU Hours, CPU Jobs, GPU Hours, GPU Jobs`

--- a/osg-collaborations-hours/fetch_collab_metrics.py
+++ b/osg-collaborations-hours/fetch_collab_metrics.py
@@ -1,0 +1,454 @@
+"""
+Fetch CPU and GPU usage metrics for collaboration-level OSPool projects from Elasticsearch.
+
+Output is CSV with columns: Project, Pool, CPU Hours, CPU Jobs, GPU Hours, GPU Jobs.
+
+NOTE: Currently requires direct access to the internal Elasticsearch instance.
+Will be updated to support a Tiger-based Elasticsearch service.
+"""
+
+from __future__ import annotations
+
+import csv
+import sys
+import json
+import argparse
+
+from datetime import datetime, timedelta
+from pathlib import Path
+from copy import deepcopy
+
+import elasticsearch
+from elasticsearch_dsl import Search, A, Q
+
+from metric_functions import get_ospool_aps, OSPOOL_COLLECTORS, print_es_error, short, valid_date, connect
+
+
+PICKLED_AP_COLLECTOR_HOSTS_CACHE_FILE = "ospool_ap_collectorhost.pickle"
+
+ELASTICSEARCH_ARGS = {
+    "--es-host": {"default": "localhost:9200"},
+    "--es-url-prefix": {},
+    "--es-index": {},
+    "--es-user": {},
+    "--es-password-file": {"type": Path},
+    "--es-use-https": {"action": "store_true"},
+    "--es-ca-certs": {},
+    "--es-timeout": {"type": int, "default": 120},
+    "--es-config-file": {
+        "type": Path,
+        "help": "JSON file containing an object that sets above ES options",
+    }
+}
+
+RESOURCE_NAME_SCRIPT_SRC = """
+String res;
+if (doc.containsKey("MachineAttrGLIDEIN_ResourceName0") && doc["MachineAttrGLIDEIN_ResourceName0.keyword"].size() > 0) {
+    res = doc["MachineAttrGLIDEIN_ResourceName0.keyword"].value;
+    emit(res);
+} else if (doc.containsKey("MATCH_EXP_JOBGLIDEIN_ResourceName") && doc["MATCH_EXP_JOBGLIDEIN_ResourceName.keyword"].size() > 0) {
+    res = doc["MATCH_EXP_JOBGLIDEIN_ResourceName.keyword"].value;
+    emit(res);
+}
+"""
+
+PROJECT_NAME_SCRIPT_SRC = """
+String proj;
+if (doc.containsKey("ProjectName") && doc["ProjectName.keyword"].size() > 0) {
+    proj = doc["ProjectName.keyword"].value.toLowerCase();
+    emit(proj);
+}
+"""
+
+CPU_HOURS_SCRIPT_SRC = """
+long cpus = 1;
+long wallclocktime = 0;
+if (doc.containsKey("RequestCpus") && doc["RequestCpus"].size() > 0) {
+    cpus = doc["RequestCpus"].value;
+}
+if (doc.containsKey("CpusProvisioned") && doc["CpusProvisioned"].size() > 0 && doc["CpusProvisioned"].value < cpus) {
+    cpus = doc["CpusProvisioned"].value;
+}
+if (doc.containsKey("RemoteWallClockTime") && doc["RemoteWallClockTime"].size() > 0) {
+    wallclocktime = doc["RemoteWallClockTime"].value;
+}
+emit((double)cpus * ((double)wallclocktime / (double)3600));
+"""
+
+
+GPU_HOURS_SCRIPT_SRC = """
+long gpus = 1;
+long wallclocktime = 0;
+if (doc.containsKey("RequestGpus") && doc["RequestGpus"].size() > 0) {
+    gpus = doc["RequestGpus"].value;
+}
+if (doc.containsKey("GpusProvisioned") && doc["GpusProvisioned"].size() > 0 && doc["GpusProvisioned"].value < gpus) {
+    gpus = doc["GpusProvisioned"].value;
+}
+if (doc.containsKey("RemoteWallClockTime") && doc["RemoteWallClockTime"].size() > 0) {
+    wallclocktime = doc["RemoteWallClockTime"].value;
+}
+emit((double)gpus * ((double)wallclocktime / (double)3600));
+"""
+
+PROJECT_NAMES = {
+    "clas12": ["clas12"],
+    "eic": ["eic", "epic"],
+    "eht": ["eht"],
+    "futurecolliders": ["futurecolliders"],
+    "gluex": ["gluex"],
+    "icecube": ["icecube"],
+    "koto": ["koto"],
+    "ligo": ["ligo_orientation", "igwn_staff"],
+    "moller": ["moller"],
+    "redtop": ["redtop"],
+    "rnog": ["rnog"],
+    "scdms": ["scdms"],
+    "solid": ["solid"],
+    "spt": ["spt", "spt.all"],
+    "xenon": ["xenon"],
+}
+
+CPU_PROJECT_SPECIFIC_RESOURCES = {
+    "icecube": [
+        "CA_SFU_T2",
+        "DESY-ZN",
+        "FZK-LCG2",
+        "NBI_T3",
+        "PDX-Coeus-CE1",
+        "UCSDT2",
+        "UKI-NORTHGRID-MAN-HEP",
+        "wuppertalprod",
+    ],
+    "spt": ["UIUC-ICC-SPT"],
+    "xenon": [
+        "IN2P3-CC",
+        "INFN-T1",
+        "NIKHEF-ELPROD",
+        "SURFsara",
+    ]
+}
+
+GPU_PROJECT_SPECIFIC_RESOURCES = {
+    "icecube": [
+        "PDX-Coeus-CE1",
+        "SDSC-Cloud",
+        "UKI-LT2-QMUL",
+    ]
+}
+
+IS_OSPOOL_JOB_FILTER = (
+    (
+        (
+            Q("terms", ScheddName__keyword=list(get_ospool_aps(include_jupyter_aps=False, pickled_ap_collector_hosts_cache=PICKLED_AP_COLLECTOR_HOSTS_CACHE_FILE))) &
+            ~Q("exists", field="LastRemotePool")
+        ) | (
+            Q("terms", LastRemotePool__keyword=list(OSPOOL_COLLECTORS))
+        )
+    ) &
+    ~(
+        Q("exists", field="TargetAnnexName") |
+        Q("terms", ResourceName=["Local Job", "2"])
+    )
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Fetch CPU/GPU usage metrics for collaboration-level OSPool projects.\n"
+            "Output is CSV: Project, Pool, CPU Hours, CPU Jobs, GPU Hours, GPU Jobs.\n\n"
+            "NOTE: Currently requires direct access to the internal Elasticsearch instance"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+
+    es_args = parser.add_argument_group("Elasticsearch-related options")
+    for name, properties in ELASTICSEARCH_ARGS.items():
+        es_args.add_argument(name, **properties)
+
+    parser.add_argument("--start", type=valid_date, metavar="YYYY-MM-DD",
+                        help="Start of the reporting period (inclusive). Defaults to yesterday.")
+    parser.add_argument("--end", type=valid_date, metavar="YYYY-MM-DD",
+                        help="End of the reporting period (exclusive). Defaults to one day after --start.")
+    parser.add_argument("outfile", type=Path,
+                        help="Output CSV file path.")
+
+    return parser.parse_args()
+
+
+def get_base_query(
+        index: str,
+        start: datetime,
+        end: datetime
+    ) -> Search:
+
+    runtime_mappings = {
+        "ResourceName": {
+            "type": "keyword",
+            "script": {
+                "source": RESOURCE_NAME_SCRIPT_SRC,
+            }
+        },
+        "ProjectNameLower": {
+            "type": "keyword",
+            "script": {
+                "source": PROJECT_NAME_SCRIPT_SRC,
+            }
+        },
+    }
+
+    query = Search(index=index) \
+                .extra(size=0, track_scores=False, track_total_hits=True) \
+                .extra(runtime_mappings=runtime_mappings) \
+                .filter("range", RecordTime={"gte": int(start.timestamp()), "lt": int(end.timestamp())}) \
+                .filter("range", RemoteWallClockTime={"gt": 0}) \
+                .query(~Q("terms", JobUniverse=[7, 12]))
+
+    return query
+
+
+def add_cpu_hours(base: Search) -> Search:
+    """Add a CpuHours runtime mapping and sum aggregation to a query."""
+    query = deepcopy(base)
+    runtime_mappings = query.to_dict().get("runtime_mappings", {})
+    runtime_mappings["CpuHours"] = {
+        "type": "double",
+        "script": {
+            "source": CPU_HOURS_SCRIPT_SRC
+        }
+    }
+    query = query.extra(runtime_mappings=runtime_mappings)
+
+    cpu_hours_agg = A(
+        "sum",
+        field="CpuHours",
+    )
+    query.aggs.metric("cpu_hours", cpu_hours_agg)
+    return query
+
+
+def add_gpu_hours(base: Search) -> Search:
+    """Add a GpuHours runtime mapping and sum aggregation to a query. Filters to jobs that requested GPUs."""
+    query = deepcopy(base).filter("range", RequestGpus={"gt": 0})
+    runtime_mappings = query.to_dict().get("runtime_mappings", {})
+    runtime_mappings["GpuHours"] = {
+        "type": "double",
+        "script": {
+            "source": GPU_HOURS_SCRIPT_SRC
+        }
+    }
+    query = query.extra(runtime_mappings=runtime_mappings)
+
+    gpu_hours_agg = A(
+        "sum",
+        field="GpuHours",
+    )
+    query.aggs.metric("gpu_hours", gpu_hours_agg)
+    return query
+
+
+def get_usage(client: elasticsearch.Elasticsearch, q: Search, gpu: bool = False) -> dict:
+    """Execute a query and return a dict with job count and CPU or GPU hours.
+
+    Returns an empty dict on error.
+    """
+    usage = {}
+    try:
+        r = q.using(client).execute()
+        if gpu:
+            label = "gpu_hours"
+            hours = r.aggregations.gpu_hours.value
+        else:
+            label = "cpu_hours"
+            hours = r.aggregations.cpu_hours.value
+        usage = {
+            "jobs": r.hits.total.value,
+            label: hours,
+        }
+    except elasticsearch.exceptions.ElasticsearchException as e:
+        print_es_error(e, file=sys.stderr)
+    except (KeyError, AttributeError, NameError):
+        print(json.dumps(r, indent=2), file=sys.stderr)
+    return usage
+
+
+### PROJECTS
+
+
+def ospool_cpu_only(client: elasticsearch.Elasticsearch, q: Search, project: str) -> dict:
+    """Return OSPool CPU usage for projects whose jobs run exclusively on OSPool."""
+    usage = {}
+
+    q = add_cpu_hours(q.filter("terms", ProjectNameLower=PROJECT_NAMES[project]))
+
+    ospool_q = q.query(IS_OSPOOL_JOB_FILTER)
+    usage["OSPool"] = get_usage(client, ospool_q)
+
+    return usage
+
+
+def clas12_cpu(client: elasticsearch.Elasticsearch, q: Search) -> dict:
+    usage = {}
+
+    q = add_cpu_hours(q.filter("terms", ProjectNameLower=PROJECT_NAMES["clas12"]))
+
+    ospool_q = q.query(IS_OSPOOL_JOB_FILTER)
+    usage["OSPool"] = get_usage(client, ospool_q)
+
+    jlab_q = q.query(~IS_OSPOOL_JOB_FILTER)
+    usage["JLAB"] = get_usage(client, jlab_q)
+
+    return usage
+
+
+def eic_cpu(client: elasticsearch.Elasticsearch, q: Search) -> dict:
+    usage = {}
+
+    q = add_cpu_hours(q.filter("terms", ProjectNameLower=PROJECT_NAMES["eic"]))
+
+    ospool_q = q.query(IS_OSPOOL_JOB_FILTER)
+    usage["OSPool"] = get_usage(client, ospool_q)
+
+    jlab_q = q.query(~IS_OSPOOL_JOB_FILTER)
+    usage["JLAB"] = get_usage(client, jlab_q)
+
+    return usage
+
+
+def gluex_cpu(client: elasticsearch.Elasticsearch, q: Search) -> dict:
+    usage = {}
+
+    q = add_cpu_hours(q.filter("terms", ProjectNameLower=PROJECT_NAMES["gluex"]))
+
+    ospool_q = q.query(IS_OSPOOL_JOB_FILTER)
+    usage["OSPool"] = get_usage(client, ospool_q)
+
+    jlab_q = q.query(~IS_OSPOOL_JOB_FILTER)
+    usage["JLAB"] = get_usage(client, jlab_q)
+
+    return usage
+
+
+def icecube_cpu(client: elasticsearch.Elasticsearch, q: Search) -> dict:
+    usage = {}
+
+    q = add_cpu_hours(q.filter("terms", ProjectNameLower=PROJECT_NAMES["icecube"]))
+    icecube_pool_filter = Q("terms", ResourceName=CPU_PROJECT_SPECIFIC_RESOURCES["icecube"])
+
+    ospool_q = q.query(IS_OSPOOL_JOB_FILTER & ~icecube_pool_filter)
+    usage["OSPool"] = get_usage(client, ospool_q)
+
+    icecube_q = q.query(icecube_pool_filter | ~IS_OSPOOL_JOB_FILTER)
+    usage["IceCube"] = get_usage(client, icecube_q)
+
+    return usage
+
+
+def icecube_gpu(client: elasticsearch.Elasticsearch, q: Search) -> dict:
+    usage = {}
+
+    q = add_gpu_hours(q.filter("terms", ProjectNameLower=PROJECT_NAMES["icecube"]))
+    icecube_pool_filter = Q("terms", ResourceName=GPU_PROJECT_SPECIFIC_RESOURCES["icecube"] + CPU_PROJECT_SPECIFIC_RESOURCES["icecube"])
+
+    ospool_q = q.query(IS_OSPOOL_JOB_FILTER & ~icecube_pool_filter)
+    usage["OSPool"] = get_usage(client, ospool_q, gpu=True)
+
+    icecube_q = q.query(IS_OSPOOL_JOB_FILTER & icecube_pool_filter)
+    usage["IceCube"] = get_usage(client, icecube_q, gpu=True)
+
+    return usage
+
+
+def spt_cpu(client: elasticsearch.Elasticsearch, q: Search) -> dict:
+    usage = {}
+
+    q = add_cpu_hours(q.filter("terms", ProjectNameLower=PROJECT_NAMES["spt"]))
+    spt_pool_filter = Q("terms", ResourceName=CPU_PROJECT_SPECIFIC_RESOURCES["spt"])
+
+    ospool_q = q.query(IS_OSPOOL_JOB_FILTER & ~spt_pool_filter)
+    usage["OSPool"] = get_usage(client, ospool_q)
+
+    spt_q = q.query(IS_OSPOOL_JOB_FILTER & spt_pool_filter)
+    usage["SPT"] = get_usage(client, spt_q)
+
+    return usage
+
+
+def xenon_cpu(client: elasticsearch.Elasticsearch, q: Search) -> dict:
+    usage = {}
+
+    q = add_cpu_hours(q.filter("terms", ProjectNameLower=PROJECT_NAMES["xenon"]))
+    xenon_pool_filter = Q("terms", ResourceName=CPU_PROJECT_SPECIFIC_RESOURCES["xenon"])
+
+    ospool_q = q.query(IS_OSPOOL_JOB_FILTER & ~xenon_pool_filter)
+    usage["OSPool"] = get_usage(client, ospool_q)
+
+    xenon_q = q.query(IS_OSPOOL_JOB_FILTER & xenon_pool_filter)
+    usage["XENON"] = get_usage(client, xenon_q)
+
+    return usage
+
+
+###
+
+
+def write_csv_rows(writer: csv.writer, project: str, cpu_usage: dict, gpu_usage: dict | None = None) -> None:
+    """Write one CSV row per pool for a project, merging CPU and GPU usage by pool name."""
+    gpu_usage = gpu_usage or {}
+    pools = list(cpu_usage) + [p for p in gpu_usage if p not in cpu_usage]
+    for pool in pools:
+        cpu = cpu_usage.get(pool, {})
+        gpu = gpu_usage.get(pool, {})
+        cpu_hours = short(cpu["cpu_hours"]) if "cpu_hours" in cpu else ""
+        cpu_jobs = short(cpu["jobs"]) if "cpu_hours" in cpu else ""
+        gpu_hours = short(gpu["gpu_hours"]) if "gpu_hours" in gpu else ""
+        gpu_jobs = short(gpu["jobs"]) if "gpu_hours" in gpu else ""
+        writer.writerow([project, pool, cpu_hours, cpu_jobs, gpu_hours, gpu_jobs])
+
+
+def main():
+    args = parse_args()
+
+    es_args = {}
+    if args.es_config_file:
+        es_args = json.load(args.es_config_file.open())
+    else:
+        es_args = {arg: v for arg, v in vars(args).items() if arg.startswith("es_")}
+    if es_args.get("es_password_file"):
+        es_args["es_pass"] = es_args.pop("es_password_file").open().read().rstrip()
+    index = es_args.pop("es_index", "osg-schedd-*")
+
+    if args.start is None:
+        args.start = (datetime.now() - timedelta(days=1)).replace(hour=0, minute=0, second=0, microsecond=0)
+    if args.end is None:
+        args.end = args.start + timedelta(days=1)
+
+    es = connect(**es_args)
+    es.info()
+
+    q = get_base_query(index, args.start, args.end)
+
+    with args.outfile.open("w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(["Project", "Pool", "CPU Hours", "CPU Jobs", "GPU Hours", "GPU Jobs"])
+
+        write_csv_rows(writer, "CLAS12", clas12_cpu(es, q))
+        write_csv_rows(writer, "EIC/ePIC", eic_cpu(es, q))
+        write_csv_rows(writer, "Event Horizon Telescope", ospool_cpu_only(es, q, "eht"))
+        write_csv_rows(writer, "Future Colliders", ospool_cpu_only(es, q, "futurecolliders"))
+        write_csv_rows(writer, "GlueX", gluex_cpu(es, q))
+        write_csv_rows(writer, "IceCube", icecube_cpu(es, q), icecube_gpu(es, q))
+        write_csv_rows(writer, "KOTO", ospool_cpu_only(es, q, "koto"))
+        write_csv_rows(writer, "LIGO-OSG", ospool_cpu_only(es, q, "ligo"))
+        write_csv_rows(writer, "MOLLER", ospool_cpu_only(es, q, "moller"))
+        write_csv_rows(writer, "REDTOP", ospool_cpu_only(es, q, "redtop"))
+        write_csv_rows(writer, "RNO-G", ospool_cpu_only(es, q, "rnog"))
+        write_csv_rows(writer, "Super CDMS", ospool_cpu_only(es, q, "scdms"))
+        write_csv_rows(writer, "SoLID", ospool_cpu_only(es, q, "solid"))
+        write_csv_rows(writer, "SPT-3G", spt_cpu(es, q))
+        write_csv_rows(writer, "XENON", xenon_cpu(es, q))
+
+
+if __name__ == "__main__":
+    main()

--- a/osg-collaborations-hours/metric_functions.py
+++ b/osg-collaborations-hours/metric_functions.py
@@ -1,0 +1,222 @@
+"""
+Helper functions and constants for OSPool metrics collection.
+
+Includes Elasticsearch connection setup, OSPool access point discovery,
+and output formatting utilities.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+import pickle
+import argparse
+import importlib.util
+
+from pathlib import Path
+from datetime import datetime
+
+import elasticsearch
+
+try:
+    import htcondor2 as htcondor
+except ImportError:
+    try:
+        import htcondor
+    except ImportError:
+        htcondor = None
+
+
+OSPOOL_COLLECTORS = {"cm-1.ospool.osg-htc.org", "cm-2.ospool.osg-htc.org", "flock.opensciencegrid.org"}
+
+OSPOOL_APS = {
+    "amundsen.grid.uchicago.edu",
+    "ap20.uc.osg-htc.org",
+    "ap2007.chtc.wisc.edu",
+    "ap21.uc.osg-htc.org",
+    "ap22.uc.osg-htc.org",
+    "ap23.uc.osg-htc.org",
+    "ap40.uw.osg-htc.org",
+    "ap41.uw.osg-htc.org",
+    "ap42.uw.osg-htc.org",
+    "ap43.uw.osg-htc.org",
+    "ap7.chtc.wisc.edu",
+    "ap7.chtc.wisc.edu@ap2007.chtc.wisc.edu",
+    "ce1.opensciencegrid.org",
+    "comses.sol.rc.asu.edu",
+    "condor.scigap.org",
+    "descmp3.cosmology.illinois.edu",
+    "gremlin.phys.uconn.edu",
+    "grid-submitter.icecube.wisc.edu",
+    "htcss-dev-ap.ospool.opensciencegrid.org",
+    "huxley-osgsub-001.sdmz.amnh.org",
+    "lambda06.rowan.edu",
+    "login-el7.xenon.ci-connect.net",
+    "login-test.osgconnect.net",
+    "login.ci-connect.uchicago.edu",
+    "login.collab.ci-connect.net",
+    "login.duke.ci-connect.net",
+    "login.snowmass21.io",
+    "login.veritas.ci-connect.net",
+    "login04.osgconnect.net",
+    "login05.osgconnect.net",
+    "mendel-osgsub-001.sdmz.amnh.org",
+    "nsgosg.sdsc.edu",
+    "os-ce1.opensciencegrid.org",
+    "os-ce1.osgdev.chtc.io",
+    "osg-moller.jlab.org",
+    "osg-prp-submit.nautilus.optiputer.net",
+    "osg-solid.jlab.org",
+    "osg-vo.isi.edu",
+    "ospool-eht.chtc.wisc.edu",
+    "scott.grid.uchicago.edu",
+    "xd-submit0000.chtc.wisc.edu",
+    "testbed",
+}
+
+
+def valid_date(date_str: str) -> datetime:
+    try:
+        return datetime.strptime(date_str, "%Y-%m-%d")
+    except ValueError:
+        raise argparse.ArgumentTypeError(f"Invalid date string, should match format YYYY-MM-DD: {date_str}")
+
+
+def connect(
+        es_host="localhost:9200",
+        es_user="",
+        es_pass="",
+        es_use_https=False,
+        es_ca_certs=None,
+        es_url_prefix=None,
+        es_timeout=120,
+        **kwargs,
+    ) -> elasticsearch.Elasticsearch:
+    """Create and return an Elasticsearch client.
+
+    Requires either both es_user and es_pass or neither. HTTPS requires es_ca_certs
+    or the certifi package to be installed.
+    """
+
+    # Split off port from host if included
+    if ":" in es_host and len(es_host.split(":")) == 2:
+        [es_host, es_port] = es_host.split(":")
+        es_port = int(es_port)
+    elif ":" in es_host:
+        print(f"Ambiguous hostname:port in given host: {es_host}")
+        sys.exit(1)
+    else:
+        es_port = 9200
+    es_client = {
+        "host": es_host,
+        "port": es_port
+    }
+
+    # Include username and password if both are provided
+    if (not es_user) ^ (not es_pass):
+        print("Only one of es_user and es_pass have been defined")
+        print("Connecting to Elasticsearch anonymously")
+    elif es_user and es_pass:
+        es_client["http_auth"] = (es_user, es_pass)
+
+    if es_url_prefix:
+        es_client["url_prefix"] = es_url_prefix
+
+    # Only use HTTPS if CA certs are given or if certifi is available
+    if es_use_https:
+        if es_ca_certs is not None:
+            es_client["ca_certs"] = str(es_ca_certs)
+        elif importlib.util.find_spec("certifi") is not None:
+            pass
+        else:
+            print("Using HTTPS with Elasticsearch requires that either es_ca_certs be provided or certifi library be installed")
+            sys.exit(1)
+        es_client["use_ssl"] = True
+        es_client["verify_certs"] = True
+
+    es_client["timeout"] = es_timeout
+    es_client.update(kwargs)
+
+    return elasticsearch.Elasticsearch([es_client])
+
+
+def get_ospool_aps(include_jupyter_aps: bool = True, pickled_ap_collector_hosts_cache: str | Path | None = None) -> set:
+    """Return the set of known OSPool access point (schedd) hostnames.
+
+    Combines three sources: a hardcoded fallback set (OSPOOL_APS), a pickle cache of
+    previously seen APs and their collector hosts, and a live query to each OSPool
+    collector (requires htcondor). The pickle cache is updated in place after each
+    live query.
+    """
+    ap_collector_hosts_cache = {}
+    cached_aps = set()
+    if pickled_ap_collector_hosts_cache is not None:
+        try:
+            with Path(pickled_ap_collector_hosts_cache).open("rb") as f:
+                ap_collector_hosts_cache = pickle.load(f)
+                for ap, collector_hosts in ap_collector_hosts_cache.items():
+                    if not include_jupyter_aps and (ap.lower().startswith("jupyter-notebook-") or ap.lower().startswith("jupyterlab-")):
+                        continue
+                    if len(set(collector_hosts) & OSPOOL_COLLECTORS) > 0:
+                        cached_aps.add(ap)
+        except Exception:
+            print(f"Could not open {pickled_ap_collector_hosts_cache}, not using CollectorHost cache")
+            pass
+    current_ospool_aps = set()
+    if htcondor is None:
+        print("Could not import htcondor, not querying APs")
+    else:
+        for collector_host in OSPOOL_COLLECTORS:
+            try:
+                collector = htcondor.Collector(collector_host)
+                aps = collector.query(htcondor.AdTypes.Schedd, projection=["Machine", "CollectorHost"])
+            except Exception:
+                continue
+            for ap in aps:
+                collector_hosts = set(re.split(r"[\s,]+", ap["CollectorHost"]))
+                ap_collector_hosts_cache[ap["Machine"]] = list(collector_hosts)
+                if not include_jupyter_aps and (ap["Machine"].lower().startswith("jupyter-notebook-") or ap["Machine"].lower().startswith("jupyterlab-")):
+                    continue
+                if collector_hosts & OSPOOL_COLLECTORS:
+                    current_ospool_aps.add(ap["Machine"])
+                if pickled_ap_collector_hosts_cache is not None:
+                    try:
+                        with Path(pickled_ap_collector_hosts_cache).open("wb") as f:
+                            pickle.dump(ap_collector_hosts_cache, f)
+                    except Exception:
+                        print(f"Could not write to {pickled_ap_collector_hosts_cache}, not saving CollectorHost cache")
+                        pass
+    return current_ospool_aps | cached_aps | OSPOOL_APS
+
+
+def print_es_error(d, depth=0, **kwargs):
+    pre = depth*"\t"
+    for k, v in d.items():
+        if k == "failed_shards":
+            print(f"{pre}{k}:", **kwargs)
+            print_es_error(v[0], depth=depth+1, **kwargs)
+        elif k == "root_cause":
+            print(f"{pre}{k}:")
+            print_es_error(v[0], depth=depth+1, **kwargs)
+        elif isinstance(v, dict):
+            print(f"{pre}{k}:")
+            print_es_error(v, depth=depth+1, **kwargs)
+        elif isinstance(v, list):
+            nt = f"\n{pre}\t"
+            print(f"{pre}{k}:\n{pre}\t{nt.join(v)}", **kwargs)
+        else:
+            print(f"{pre}{k}:\t{v}", **kwargs)
+
+
+def short(n: int | float) -> str:
+    """Format a large number with K/M suffix for compact display (e.g. 1461000 -> '1.461M')."""
+    if not (isinstance(n, int) or isinstance(n, float)):
+        print(f"{n} is not numeric")
+        return str(n)
+    suffixes = ["", "K", "M"]
+    out = str(int(n))
+    for i, suffix in enumerate(suffixes):
+        reduced = n / 10**(3*i)
+        if reduced >= 1 and i > 0:
+            out = f"{round(reduced, 3):.3f}{suffix}"
+    return out


### PR DESCRIPTION
This script computes usage data from our Elasticsearch job history indexes, separated by project and pool. Currently, the script must be run on a specific, internal server.